### PR TITLE
Fixed failure for vim fugituve on CentOS 7

### DIFF
--- a/roles/vim/defaults/main.yml
+++ b/roles/vim/defaults/main.yml
@@ -28,4 +28,4 @@ vim_plugins:
   - name: luacheck
     url: https://github.com/mpeterv/luacheck
   - name: fugitive.vim
-    url: https://tpope.io/vim/fugitive
+    url: https://tpope.io/vim/fugitive.git


### PR DESCRIPTION
The git clone of the fugitive.vim repo failed on CentOS 7. This is related to the url. That was missing `.git` at the end.