### PR TITLE
Fix/catppuccin options

### DIFF
--- a/roles/vim/files/init.vim
+++ b/roles/vim/files/init.vim
@@ -9,8 +9,8 @@ if v:lua.vim.version().major == 0 && v:lua.vim.version().minor < 8
     lua vim.cmd("colorscheme oxocarbon")
 else
     " Configure catppuccin on recent neovim
-    colorscheme catppuccin
     lua require("catppuccin").setup({flavour = "latte"})
+    colorscheme catppuccin
 endif
 
 " Set the cursor to a block in all modes

--- a/roles/vim/files/vimrc
+++ b/roles/vim/files/vimrc
@@ -3,6 +3,9 @@ call plug#begin(expand('~/.vim/plugged'))
 
 "*****************************************************************************
 "" Plug install packages
+"" Bootstrap with:
+""
+"" VIM_BOOTSTRAP=true vim -u ~/.vimrc +'PlugInstall --sync' +qa
 "*****************************************************************************
 Plug 'vim-airline/vim-airline'
 Plug 'vim-airline/vim-airline-themes'
@@ -30,8 +33,8 @@ if $VIM_BOOTSTRAP == "true" | finish | endif
 
 if has('lua') && v:version >= 900
     " Configure catppuccin on recent neovim
-    colorscheme catppuccin
     lua require("catppuccin").setup({flavour = "latte"})
+    colorscheme catppuccin
 else
     colo default
 endif


### PR DESCRIPTION
My latte theme did not always load properly and sometimes it switched from dark to light during start of (n)vim. That is because the theme was activated before the theme was defined. That way it fell back to auto detection, which not always works properly in a SSH session. Also the flicker from dark to light during start was anoying.